### PR TITLE
chore: update references to config repo

### DIFF
--- a/modules/ROOT/pages/cli.adoc
+++ b/modules/ROOT/pages/cli.adoc
@@ -99,7 +99,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA
 naYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==
 -----END PUBLIC KEY-----' > key.pub
 
-$ wget -q https://github.com/enterprise-contract/config/raw/main/slsa3/policy.yaml
+$ wget -q https://github.com/conforma/config/raw/main/slsa3/policy.yaml
 ----
 
 Now we can run the ec like this:
@@ -136,7 +136,7 @@ You can now modify the `policy.yaml` file and re-run the `ec validate image`
 command to try different policy configurations. See
 xref:ecc:ROOT:index.adoc[the configuration docs] for more information on the
 `policy.yaml` file, or take a look at the examples
-link:https://github.com/enterprise-contract/config[here].
+link:https://github.com/conforma/config[here].
 
 See also the how-to on xref:reproducing-a-konflux-conforma-report.adoc[reproducing the Conforma output from a Konflux
 integration test].

--- a/modules/ROOT/pages/configuration.adoc
+++ b/modules/ROOT/pages/configuration.adoc
@@ -10,7 +10,7 @@ it can be fetched from a git url.
 For xref:cli.adoc[command line use] of Conforma a local file can also be used.
 
 There are some pre-defined configuration files available
-link:https://github.com/enterprise-contract/config[here].
+link:https://github.com/conforma/config[here].
 
 == Finding the configuration used
 

--- a/modules/ROOT/pages/custom-config.adoc
+++ b/modules/ROOT/pages/custom-config.adoc
@@ -32,7 +32,7 @@ Find the `spec` key and add `params` underneath it like this:
 spec:
   params:
     - name: POLICY_CONFIGURATION
-      value: github.com/enterprise-contract/config//slsa3
+      value: github.com/conforma/config//slsa3
 …
 ----
 
@@ -51,9 +51,9 @@ apiVersion: appstudio.redhat.com/v1alpha1
 Save the file to update the CR in the cluster.
 
 NOTE: The config file specified in the above example is
-link:https://github.com/enterprise-contract/config/blob/main/slsa3/policy.yaml[this
+link:https://github.com/conforma/config/blob/main/slsa3/policy.yaml[this
 one]. There are some other
-link:https://github.com/enterprise-contract/config[predefined configurations
+link:https://github.com/conforma/config[predefined configurations
 available] in that same repo. You can of course substitute your own git repo
 with your own customized policy file.
 


### PR DESCRIPTION
This commit updates references to the config repository from `enterprise-contract/config` to `conforma/config`.

Ref: EC-1115